### PR TITLE
fix: rename data provider to match provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,18 @@ or resource outputs.
 
 ## Using the provider
 
-This provider has a single _validate_ data source.
+This provider has a single _validation_ data source.
 
 ```hcl
-data "validate" "foo" {
+terraform {
+  required_providers {
+    validation = {
+      source = "articulate/validation"
+    }
+  }
+}
+
+data "validation" "foo" {
   condition     = var.foo != "" || var.bar != ""
   error_message = "You must set foo or bar."
 }

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,6 +1,6 @@
 terraform {
   required_providers {
-    validate = {
+    validation = {
       source = "articulate/validation"
     }
   }
@@ -14,7 +14,7 @@ variable "bar" {
   default = ""
 }
 
-data "validate" "test" {
+data "validation" "test" {
   condition     = var.foo != "" || var.bar != ""
   error_message = "You must set foo or bar."
 }

--- a/internal/provider/data_source_validate_test.go
+++ b/internal/provider/data_source_validate_test.go
@@ -13,18 +13,18 @@ func TestAccDataSourceValidate(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: `
-data "validate" "foo" {
+data "validation" "foo" {
   condition     = true
   error_message = "Foo is invalid."
 }`,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestMatchResourceAttr(
-						"data.validate.foo", "id", regexp.MustCompile("^Foo is invalid")),
+						"data.validation.foo", "id", regexp.MustCompile("^Foo is invalid")),
 				),
 			},
 			{
 				Config: `
-data "validate" "bar" {
+data "validation" "bar" {
   condition     = false
   error_message = "Bar is invalid."
 }`,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -24,7 +24,7 @@ func New(version string) func() *schema.Provider {
 	return func() *schema.Provider {
 		return &schema.Provider{
 			DataSourcesMap: map[string]*schema.Resource{
-				"validate": dataSourceValidate(),
+				"validation": dataSourceValidate(),
 			},
 		}
 	}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -10,7 +10,7 @@ import (
 // The factory function will be invoked for every Terraform CLI command executed
 // to create a provider server to which the CLI can reattach.
 var providerFactories = map[string]func() (*schema.Provider, error){
-	"validate": func() (*schema.Provider, error) {
+	"validation": func() (*schema.Provider, error) {
 		return New("dev")(), nil
 	},
 }


### PR DESCRIPTION
If the data provider name doesn't match, it won't be able to find it. Rename `validate` to `validation`. Update docs