### PR TITLE
docs: add callout that this provider is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Terraform Provider Validation
 
+> __DEPRECATED__: Starting with Terraform 1.2, you can acomplish more complex
+> validation using [preconditions](https://developer.hashicorp.com/terraform/tutorials/configuration-language/custom-conditions#add-preconditions).
+
 Terraform provides a way to add validation to variables, but you can't use other
 variables in this validation. This allows you to do complex validation on variables
 or resource outputs.


### PR DESCRIPTION
This provider was created because you couldn't add var validation referencing another variable. In Terraform 1.2, you can add a precondition to resources that can do the same type of validation that this provider allowed you to do